### PR TITLE
Use native String#repeat if available.

### DIFF
--- a/behave.js
+++ b/behave.js
@@ -4,7 +4,7 @@ var Behave = Behave || function (userOpts) {
 
     // Fast repeat, uses the `Exponentiation by squaring` algorithm.
     if (typeof String.prototype.repeat !== 'function') {
-    	String.prototype.repeat = function(times) {
+        String.prototype.repeat = function(times) {
             if (times < 1) return '';
             if (times % 2) return this.repeat(times - 1) + this;
             var half = this.repeat(times / 2);


### PR DESCRIPTION
Also, MUCH faster algorithm otherwise.

String.prototype.repeat made it through to new ECMAScript standard, so it will be bad to overwrite existing methods.

Taken from my es6-shim (https://github.com/paulmillr/es6-shim/blob/master/es6-shim.js).
